### PR TITLE
Example fix for yaml parsing order issue

### DIFF
--- a/enconf.py
+++ b/enconf.py
@@ -1,7 +1,7 @@
 import os
 import re
 import yaml
-from collections import deque
+from collections import deque, OrderedDict
 import logging
 
 log = logging.getLogger(__name__)
@@ -61,13 +61,14 @@ class EnConf(object):
         :param config_file: (str or pathlib) Path to config file
         """
         with open(str(config_file), 'r') as f:
-            self.config = yaml.load(f)
+            self.config = ordered_load(f)
         self.set_env_vars()
 
     def set_env_vars(self):
         """
         Parse and set all environmental variables
         """
+
         log.info('-'*79)
         for k, v in self.config.items():
             for i in v:
@@ -124,3 +125,15 @@ def main():
 
 if __name__ == '__main__':
     main()
+
+
+def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
+    class OrderedLoader(Loader):
+        pass
+    def construct_mapping(loader, node):
+        loader.flatten_mapping(node)
+        return object_pairs_hook(loader.construct_pairs(node))
+    OrderedLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        construct_mapping)
+    return yaml.load(stream, OrderedLoader)


### PR DESCRIPTION
When iterating over the items in `self.config` [line 72](https://github.com/evileyepictures/eep-enconf/compare/master...josh-t:master#diff-ecd7c0af75c1461c1a94c5c13eaaa8dbL72) it is possible that you might process template env variable strings that are defined before other templates they require. In the test case I was looking into, an **Rv** block (which required **Global**) was returned by `items()` before **Global**. The `set_env_vars` method failed because the **Global** vars hadn't been expanded and set yet. 

This fix is a suggestion/example of one way to address this (though certainly not the only one). It overrides the default `yaml` load to return an `OrderedDict` representation of the `.yml` file. This maintains the order and ensures `self.config.items()` returns the sections in the ordered they're defined in the file.

> NOTE: I found this while debugging a SG support ticket submitted by EEP. I will reference this PR there to complete the loop. Hope this helps!